### PR TITLE
Add phone_number and address to employee_profiles

### DIFF
--- a/database/migrations/2021_08_03_095311_add_phone_number_and_address_to_employer_profiles.php
+++ b/database/migrations/2021_08_03_095311_add_phone_number_and_address_to_employer_profiles.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPhoneNumberAndAddressToEmployerProfiles extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('employer_profiles', function (Blueprint $table) {
+            $table->string('phone_number')->nullable();
+            $table->string('address')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('employer_profiles', function (Blueprint $table) {
+            $table->dropColumn('phone_number');
+            $table->dropColumn('address');
+        });
+    }
+}


### PR DESCRIPTION
## Related Tickets
- [#39172](https://edu-redmine.sun-asterisk.vn/issues/39172)

## WHAT (optional)
Add `phone_number` and `address` to `employee_profiles` table

## HOW
Create a new migration to add the `phone_number` and `address` fields.

## WHY (optional)
Missing `phone_number` and `address` fields.

## Evidence (Screenshot or Video)

## WHY (optional)

## Evidence (Screenshot or Video)
