### PR TITLE
Fix bug when deleting a job

### DIFF
--- a/database/migrations/2021_08_16_070915_alter_job_id_foreign_key_of_the_comments_table.php
+++ b/database/migrations/2021_08_16_070915_alter_job_id_foreign_key_of_the_comments_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterJobIdForeignKeyOfTheCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        //
+        Schema::table('comments', function (Blueprint $table) {
+            $table->dropForeign(['job_id']);
+            $table
+                ->foreign('job_id')
+                ->on('jobs')
+                ->references('id')
+                ->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->dropForeign(['job_id']);
+            $table
+                ->foreign('job_id')
+                ->on('jobs')
+                ->references('id');
+        });
+    }
+}

--- a/resources/js/admin.js
+++ b/resources/js/admin.js
@@ -167,8 +167,8 @@ function initJobsTable() {
     });
 
     let deleteJobUrl = '';
-    $(document).on('click', 'button#delete', () => {
-        deleteJobUrl = $('button#delete').val();
+    $(document).on('click', 'button#delete', function () {
+        deleteJobUrl = $(this).val();
     });
 
     $(document).on('click', '.btn-delete-confirm', function () {


### PR DESCRIPTION
## Related Tickets
- [#40258](https://edu-redmine.sun-asterisk.vn/issues/40258)

## WHAT (optional)
Fix bug when deleting a job

## HOW
Create a new migration to alter the `job_id` foreign key of
the comments table to cascade on delete.

## WHY (optional)
The jobs table is the parent in the relationship `jobs - comments`.
Therefore, a job cannot be deleted if it had any comments.

## Evidence (Screenshot or Video)
